### PR TITLE
Fixed#1 : Loader Not Displaying on Page Load

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -11,7 +11,7 @@ window.addEventListener("load", function () {
   setTimeout(() => {
     preloader.classList.add("loaded");
     document.body.classList.add("loaded");
-  }, 0); 
+  }, 2500); 
 });
 
 


### PR DESCRIPTION
I have fixed the issue please have a look at it . This issue was caused because of incorrect time value. By default it was loading for 0 seconds but now I have made it to 2.5 sec.

Contributor ---> Avansh2006