### PR TITLE
display loader while page loads (issue #1)

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -8,10 +8,8 @@
 const preloader = document.querySelector("[data-preaload]");
 
 window.addEventListener("load", function () {
-  setTimeout(() => {
-    preloader.classList.add("loaded");
-    document.body.classList.add("loaded");
-  }, 0); 
+  preloader.classList.add("loaded");
+  document.body.classList.add("loaded");
 });
 
 


### PR DESCRIPTION
I have made the loading animation display until the contents of the website have loaded.
I removed the `setTimeout` with a delay of `0`  which made the website display immediately after loading giving no time to display the loading animation.
Please review and merge.